### PR TITLE
Custom hostname support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ Role Variables
 *Default value*: `localhost`  
 *Description*: Option to delegate tasks for Zerotier API calls. This is useful in a situation where API calls can only be made from a white-listed management server, for example.
 
+### zerotier_enable_custom_hostname
+*Type*: boolean
+*Default value*: `false`  
+*Description*: Option to allow the use of a custom name in Zero Tier. To be used in conjunction with zerotier_member_custom_hostname
+
+### zerotier_member_custom_hostname
+*Type*: string
+*Default value*:   
+*Description*: Sets the value of the variable as the name of the device in Zero Tier
+
+
 Example Playbook
 ----------------
 
@@ -87,6 +98,8 @@ Example Inventory
 
     [webservers:vars]
     zerotier_member_description='<AppName> webserver'
+    zerotier_enable_custom_hostname=true
+    zerotier_member_custom_hostname=custom_webserver_name
 
     [dbservers:vars]
     zerotier_member_description='<AppName> db cluster node'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@ zerotier_api_delegate: localhost
 zerotier_apt_state: present
 zerotier_member_register_short_hostname: "{{ zerotier_register_short_hostname | default(false) }}" # For backwards compatibility
 zerotier_authorize_member: true
+zerotier_enable_custom_hostname: false

--- a/tasks/authorize_node.yml
+++ b/tasks/authorize_node.yml
@@ -34,6 +34,47 @@
 
   when:
   - not ansible_check_mode
+  - not zerotier_enable_custom_hostname
+  tags:
+  - configuration
+  become: false
+
+- block:
+  - name: Authorize new members to network
+    uri:
+      url: "{{ zerotier_api_url }}/api/network/{{ zerotier_network_id }}/member/{{ ansible_local['zerotier']['node_id'] }}"
+      method: POST
+      headers:
+        Authorization: bearer {{ zerotier_api_accesstoken }}
+      body:
+        hidden: false
+        config:
+          authorized: "{{ zerotier_authorize_member }}"
+      body_format: json
+    register: auth_apiresult
+    delegate_to: "{{ zerotier_api_delegate }}"
+    when:
+    - ansible_local['zerotier']['networks'][zerotier_network_id] is not defined or
+      ansible_local['zerotier']['networks'][zerotier_network_id]['status'] != 'OK'
+
+  - name: Configure members in network
+    uri:
+      url: "{{ zerotier_api_url }}/api/network/{{ zerotier_network_id }}/member/{{ ansible_local['zerotier']['node_id'] }}"
+      method: POST
+      headers:
+        Authorization: bearer {{ zerotier_api_accesstoken }}
+      body:
+        name: "{{ zerotier_member_custom_hostname }}"        
+        description: "{{ zerotier_member_description | default() }}"
+        config:
+          ipAssignments: "{{ zerotier_member_ip_assignments | default([]) | list }}"
+      body_format: json
+    register: conf_apiresult
+    delegate_to: "{{ zerotier_api_delegate }}"
+
+  when:
+  - not ansible_check_mode
+  - zerotier_enable_custom_hostname
   tags:
   - configuration
   become: false

--- a/tasks/authorize_node.yml
+++ b/tasks/authorize_node.yml
@@ -24,7 +24,7 @@
       headers:
         Authorization: bearer {{ zerotier_api_accesstoken }}
       body:
-        name: "{{ zerotier_member_register_short_hostname | ternary(inventory_hostname_short, inventory_hostname) }}"
+        name: "{{ zerotier_member_register_short_hostname_custom | default(zerotier_member_register_short_hostname | ternary(inventory_hostname_short, inventory_hostname)) }}"        
         description: "{{ zerotier_member_description | default() }}"
         config:
           ipAssignments: "{{ zerotier_member_ip_assignments | default([]) | list }}"

--- a/tasks/authorize_node.yml
+++ b/tasks/authorize_node.yml
@@ -17,7 +17,7 @@
     - ansible_local['zerotier']['networks'][zerotier_network_id] is not defined or
       ansible_local['zerotier']['networks'][zerotier_network_id]['status'] != 'OK'
 
-  - name: Configure members in network
+  - name: Configure members in network with inventory hostname
     uri:
       url: "{{ zerotier_api_url }}/api/network/{{ zerotier_network_id }}/member/{{ ansible_local['zerotier']['node_id'] }}"
       method: POST
@@ -57,7 +57,7 @@
     - ansible_local['zerotier']['networks'][zerotier_network_id] is not defined or
       ansible_local['zerotier']['networks'][zerotier_network_id]['status'] != 'OK'
 
-  - name: Configure members in network
+  - name: Configure members in network with custom name
     uri:
       url: "{{ zerotier_api_url }}/api/network/{{ zerotier_network_id }}/member/{{ ansible_local['zerotier']['node_id'] }}"
       method: POST

--- a/tasks/authorize_node.yml
+++ b/tasks/authorize_node.yml
@@ -64,7 +64,7 @@
       headers:
         Authorization: bearer {{ zerotier_api_accesstoken }}
       body:
-        name: "{{ zerotier_member_custom_hostname }}"        
+        name: "{{ zerotier_member_custom_hostname | default(zerotier_member_register_short_hostname | ternary(inventory_hostname_short, inventory_hostname)) }}"        
         description: "{{ zerotier_member_description | default() }}"
         config:
           ipAssignments: "{{ zerotier_member_ip_assignments | default([]) | list }}"


### PR DESCRIPTION
Adds support for the use of a custom name in Zero Tier.
In my current use case, the Ansible host does not have its final inventory_hostname set at the time of this role running. 

